### PR TITLE
SD-18: Fixing identity ui routing

### DIFF
--- a/storkdork/StorkDorkMain/Program.cs
+++ b/storkdork/StorkDorkMain/Program.cs
@@ -9,6 +9,7 @@ using StorkDorkMain.DAL.Concrete;
 using StorkDorkMain.Data;
 using Microsoft.AspNetCore.Identity;
 using StorkDork.Areas.Identity.Data;
+using Microsoft.AspNetCore.Identity.UI.Services;
 
 internal class Program
 {
@@ -23,6 +24,9 @@ internal class Program
 
         // Add services to the container.
         builder.Services.AddControllersWithViews();
+
+        // Needed for identity ui to route properly
+        builder.Services.AddRazorPages();
 
         builder.Services.AddControllersWithViews().AddRazorRuntimeCompilation();
 
@@ -54,6 +58,8 @@ internal class Program
         builder.Services.AddScoped<IBirdRepository, BirdRepository>();
 
         builder.Services.AddSwaggerGen();
+
+        builder.Services.AddSingleton<IEmailSender, NoOpEmailSender>();
 
         var app = builder.Build();
 
@@ -97,6 +103,18 @@ internal class Program
             pattern: "BirdLog/{action=Index}/{id?}",
             defaults: new { controller = "BirdLog" });
 
+        // Needed for identity ui routing to work
+        app.MapRazorPages();
+
         app.Run();
+    }
+}
+
+// Dummy email to satisfy identity requiring email sending. WILL DELETE LATER 
+public class NoOpEmailSender : IEmailSender
+{
+    public Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        return Task.CompletedTask; // Does nothing, but satisfies the requirement
     }
 }

--- a/storkdork/StorkDorkMain/Views/Shared/_Layout.cshtml
+++ b/storkdork/StorkDorkMain/Views/Shared/_Layout.cshtml
@@ -36,10 +36,11 @@
                         <li class="nab-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Map">Map</a>
 
-                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="BirdLog" asp-action="Index">Bird Log</a>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="BirdLog" asp-action="Index">Bird
+                                Log</a>
                         </li>
-                        
+
 
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Leaflet" asp-action="Map">Map</a>
@@ -47,10 +48,29 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-controller="Search" asp-action="Index">Search Birds</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Search" asp-action="Index">Search Birds</a>
+                    </ul>
 
-                        </li>
+                    <ul class="navbar-nav ms-auto">
+                        @if (User.Identity.IsAuthenticated)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage">Profile</a>
+                            </li>
+                            <li class="nav-item">
+                                <form method="post" asp-area="Identity" asp-page="/Account/Logout">
+                                    <button type="submit" class="nav-link btn btn-link">Logout</button>
+                                </form>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Login">Login</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Register">Register</a>
+                            </li>
+                        }
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fixed a couple things to allow for the identity routing to work properly. Navbar now has login and register pages accessible, pushed to the right. Should be last pr for a while, while I start to get to work on SD-18